### PR TITLE
rewise iranian postal code validation

### DIFF
--- a/src/DNTPersianUtils.Core/Validators/IranCodesUtils.cs
+++ b/src/DNTPersianUtils.Core/Validators/IranCodesUtils.cs
@@ -10,7 +10,7 @@ namespace DNTPersianUtils.Core
         private static readonly Regex _matchIranianMobileNumber1 = new Regex(@"^(((98)|(\+98)|(0098)|0)(9){1}[0-9]{9})+$", options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex _matchIranianMobileNumber2 = new Regex(@"^(9){1}[0-9]{9}$", options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex _matchIranianPhoneNumber = new Regex("^[2-9][0-9]{7}$", options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex _matchIranianPostalCode = new Regex(@"^(\d{5}-?\d{5})$", options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex _matchIranianPostalCode = new Regex(@"\b(?!(\d)\1{3})[13-9]{4}[1346-9][013-9]{5}\b", options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Validate Iranian mobile number


### PR DESCRIPTION
Iranian postal code validation:
It's all numeric.
10 digit count.
don't use 0 in first 5 digit.
don't use 2 in postal code.
First 4 digit is not the same.
The 5th digit cannot be 5.
all digits aren't the same.