### PR TITLE
Performance issue and unnecessary memory allocation when using `ToPersianNumbers` method

### DIFF
--- a/src/DNTPersianUtils.Core.Tests/PersianNumbersUtilsTests.cs
+++ b/src/DNTPersianUtils.Core.Tests/PersianNumbersUtilsTests.cs
@@ -6,10 +6,31 @@ namespace DNTPersianUtils.Core.Tests
     public class PersianNumbersUtilsTests
     {
         [TestMethod]
-        public void Test_ToPersianNumbers_Works()
+        public void Test_English_ToPersianNumbers_Works()
         {
             var actual = 123.ToPersianNumbers();
             Assert.AreEqual(expected: "۱۲۳", actual: actual);
+        }
+
+        [TestMethod]
+        public void Test_Arabic_ToPersianNumbers_Works()
+        {
+            var actual = "\u06F1\u06F2\u06F3".ToPersianNumbers();
+            Assert.AreEqual(expected: "۱۲۳", actual: actual);
+        }
+
+        [TestMethod]
+        public void Test_Persian_ToEnglishNumbers_Works()
+        {
+            var actual = "١٢٣".ToEnglishNumbers();
+            Assert.AreEqual(expected: "123", actual: actual);
+        }
+
+        [TestMethod]
+        public void Test_Arabic_ToEnglishNumbers_Works()
+        {
+            var actual = "\u06F1\u06F2\u06F3".ToEnglishNumbers();
+            Assert.AreEqual(expected: "123", actual: actual);
         }
     }
 }

--- a/src/DNTPersianUtils.Core/PersianNumbersUtils.cs
+++ b/src/DNTPersianUtils.Core/PersianNumbersUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text;
 
 namespace DNTPersianUtils.Core
 {
@@ -53,20 +54,69 @@ namespace DNTPersianUtils.Core
         public static string ToPersianNumbers(this string data)
         {
             if (string.IsNullOrWhiteSpace(data)) return string.Empty;
-            return
-               data
-                .ToEnglishNumbers()
-                .Replace("0", "\u06F0")
-                .Replace("1", "\u06F1")
-                .Replace("2", "\u06F2")
-                .Replace("3", "\u06F3")
-                .Replace("4", "\u06F4")
-                .Replace("5", "\u06F5")
-                .Replace("6", "\u06F6")
-                .Replace("7", "\u06F7")
-                .Replace("8", "\u06F8")
-                .Replace("9", "\u06F9")
-                .Replace(".", ",");
+
+            var strBuilder = new StringBuilder(data);
+            for (var i = 0; i < strBuilder.Length; i++)
+            {
+                switch (strBuilder[i])
+                {
+                    case '0':
+                    case '\u0660':
+                        strBuilder[i] = '\u06F0';
+                        break;
+
+                    case '1':
+                    case '\u0661':
+                        strBuilder[i] = '\u06F1';
+                        break;
+
+                    case '2':
+                    case '\u0662':
+                        strBuilder[i] = '\u06F2';
+                        break;
+
+                    case '3':
+                    case '\u0663':
+                        strBuilder[i] = '\u06F3';
+                        break;
+
+                    case '4':
+                    case '\u0664':
+                        strBuilder[i] = '\u06F4';
+                        break;
+
+                    case '5':
+                    case '\u0665':
+                        strBuilder[i] = '\u06F5';
+                        break;
+
+                    case '6':
+                    case '\u0666':
+                        strBuilder[i] = '\u06F6';
+                        break;
+
+                    case '7':
+                    case '\u0667':
+                        strBuilder[i] = '\u06F7';
+                        break;
+
+                    case '8':
+                    case '\u0668':
+                        strBuilder[i] = '\u06F8';
+                        break;
+
+                    case '9':
+                    case '\u0669':
+                        strBuilder[i] = '\u06F9';
+                        break;
+
+                    default:
+                        strBuilder[i] = strBuilder[i];
+                        break;
+                }
+            }
+
+            return strBuilder.ToString();
         }
 
         /// <summary>
@@ -77,28 +127,69 @@ namespace DNTPersianUtils.Core
         public static string ToEnglishNumbers(this string data)
         {
             if (string.IsNullOrWhiteSpace(data)) return string.Empty;
-            return
-               data.Replace("\u0660", "0") //٠
-                   .Replace("\u06F0", "0") //۰
-                   .Replace("\u0661", "1") //١
-                   .Replace("\u06F1", "1") //۱
-                   .Replace("\u0662", "2") //٢
-                   .Replace("\u06F2", "2") //۲
-                   .Replace("\u0663", "3") //٣
-                   .Replace("\u06F3", "3") //۳
-                   .Replace("\u0664", "4") //٤
-                   .Replace("\u06F4", "4") //۴
-                   .Replace("\u0665", "5") //٥
-                   .Replace("\u06F5", "5") //۵
-                   .Replace("\u0666", "6") //٦
-                   .Replace("\u06F6", "6") //۶
-                   .Replace("\u0667", "7") //٧
-                   .Replace("\u06F7", "7") //۷
-                   .Replace("\u0668", "8") //٨
-                   .Replace("\u06F8", "8") //۸
-                   .Replace("\u0669", "9") //٩
-                   .Replace("\u06F9", "9") //۹
-                   ;
+
+            var strBuilder = new StringBuilder(data);
+            for (var i = 0; i < strBuilder.Length; i++)
+            {
+                switch (strBuilder[i])
+                {
+                    case '\u06F0':
+                    case '\u0660':
+                        strBuilder[i] = '0';
+                        break;
+
+                    case '\u06F1':
+                    case '\u0661':
+                        strBuilder[i] = '1';
+                        break;
+
+                    case '\u06F2':
+                    case '\u0662':
+                        strBuilder[i] = '2';
+                        break;
+
+                    case '\u06F3':
+                    case '\u0663':
+                        strBuilder[i] = '3';
+                        break;
+
+                    case '\u06F4':
+                    case '\u0664':
+                        strBuilder[i] = '4';
+                        break;
+
+                    case '\u06F5':
+                    case '\u0665':
+                        strBuilder[i] = '5';
+                        break;
+
+                    case '\u06F6':
+                    case '\u0666':
+                        strBuilder[i] = '6';
+                        break;
+
+                    case '\u06F7':
+                    case '\u0667':
+                        strBuilder[i] = '7';
+                        break;
+
+                    case '\u06F8':
+                    case '\u0668':
+                        strBuilder[i] = '8';
+                        break;
+
+                    case '\u06F9':
+                    case '\u0669':
+                        strBuilder[i] = '9';
+                        break;
+
+                    default:
+                        strBuilder[i] = strBuilder[i];
+                        break;
+                }
+            }
+
+            return strBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
Consider the following codes
![1](https://user-images.githubusercontent.com/1659032/87473947-88de6a80-c637-11ea-9864-b592a272a322.jpg)

In such a scenario calling chain of `Replace` will cause heap fragmentation and as you know each time a new string will be created and calling `ToEnglishNumbers` before replacing English numbers with Persian numbers makes it much worse. You can see the impact of swapping `Replace` with `StringBuilder`:
![d0](https://user-images.githubusercontent.com/1659032/87474429-5123f280-c638-11ea-8896-0f440042fa38.jpg)
![d7](https://user-images.githubusercontent.com/1659032/87474438-54b77980-c638-11ea-8441-cc32920063e0.jpg)
![d8](https://user-images.githubusercontent.com/1659032/87474443-56813d00-c638-11ea-85b6-97f418a4be93.jpg)
