### PR TITLE
Add AttributeTargets.Parameter to validation attributes. 

### DIFF
--- a/src/DNTPersianUtils.Core/Validators/ShouldContainOnlyPersianLettersAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ShouldContainOnlyPersianLettersAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid Persian letter.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ShouldContainOnlyPersianLettersAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ShouldContainOnlyPersianNumbersAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ShouldContainOnlyPersianNumbersAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid Persian number.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ShouldContainOnlyPersianNumbersAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ShouldContainPersianLettersOrNumbersAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ShouldContainPersianLettersOrNumbersAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid Persian letter.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ShouldContainPersianLettersOrNumbersAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranShebaNumberAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranShebaNumberAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranShebaNumber.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranShebaNumberAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranShetabNumberAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranShetabNumberAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranShetabNumber.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranShetabNumberAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranianMobileNumberAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranianMobileNumberAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranianMobileNumber.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranianMobileNumberAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranianNationalCodeAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranianNationalCodeAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranianNationalCode.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranianNationalCodeAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranianNationalLegalCodeAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranianNationalLegalCodeAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranianNationalCode.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranianNationalLegalCodeAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranianPhoneNumberAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranianPhoneNumberAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranianPhoneNumber.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranianPhoneNumberAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidIranianPostalCodeAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidIranianPostalCodeAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid IranianPostalCode.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidIranianPostalCodeAttribute : ValidationAttribute
     {
         /// <summary>

--- a/src/DNTPersianUtils.Core/Validators/ValidPersianDateTimeAttribute.cs
+++ b/src/DNTPersianUtils.Core/Validators/ValidPersianDateTimeAttribute.cs
@@ -6,7 +6,7 @@ namespace DNTPersianUtils.Core
     /// <summary>
     /// Determines whether the specified value of the object is a valid PersianDateTime.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public sealed class ValidPersianDateTimeAttribute : ValidationAttribute
     {
         /// <summary>


### PR DESCRIPTION
Validation attributes cannot be applied to the C# 9 `record` type. To support record type validation, I've added `AttributeTargets.Parameter` to the `AttributeUsage`.

![recoed-type](https://user-images.githubusercontent.com/1659032/100489747-820a4d00-312b-11eb-9693-136a6ca02799.JPG)
