### PR TITLE
fix: string length validation in IranianNationalCode method.

### DIFF
--- a/src/DNTPersianUtils.Core.Tests/NationalCodeUtilsTests.cs
+++ b/src/DNTPersianUtils.Core.Tests/NationalCodeUtilsTests.cs
@@ -10,7 +10,7 @@ public class NationalCodeUtilsTests
     {
         Assert.AreEqual(true, "0010350829".IsNumber());
     }
-
+    
     [TestMethod]
     public void TestIsNumber2()
     {
@@ -70,6 +70,12 @@ public class NationalCodeUtilsTests
     public void NationalCodeValidationTestShortString()
     {
         Assert.AreEqual(false, "0254".IsValidIranianNationalCode());
+    }
+
+    [TestMethod]
+    public void NationalCodeValidationTestShortString2()
+    {
+        Assert.AreEqual(false, "221".IsValidIranianNationalCode());
     }
 
     [TestMethod]

--- a/src/DNTPersianUtils.Core.Tests/NationalLegalCodeUtilsTests.cs
+++ b/src/DNTPersianUtils.Core.Tests/NationalLegalCodeUtilsTests.cs
@@ -65,6 +65,12 @@ public class NationalLegalCodeUtilsTests
         Assert.AreEqual(false, "0254".IsValidIranianNationalLegalCode());
     }
 
+    [TestMethod]
+    public void NationalLegalCodeValidationTestShortString2()
+    {
+        Assert.AreEqual(false, "221".IsValidIranianNationalLegalCode());
+    }
+
     [DataTestMethod]
     [DataRow("14005893875")]
     [DataRow("14006278162")]

--- a/src/DNTPersianUtils.Core/Validators/NationalCodeUtils.cs
+++ b/src/DNTPersianUtils.Core/Validators/NationalCodeUtils.cs
@@ -34,13 +34,14 @@ public static class NationalCodeUtils
 
         nationalCode = nationalCode.ToEnglishNumbers();
 
-        nationalCode = nationalCode.PadLeft(10, '0');
-
+        const int initialZeros = 2;
         const int nationalCodeLength = 10;
-        if (nationalCode.Length != nationalCodeLength)
+        if (nationalCode.Length < nationalCodeLength - initialZeros || nationalCode.Length > nationalCodeLength)
         {
             return false;
         }
+
+        nationalCode = nationalCode.PadLeft(10, '0');
 
         if (!nationalCode.IsNumber())
         {

--- a/src/DNTPersianUtils.Core/Validators/NationalLegalCodeUtils.cs
+++ b/src/DNTPersianUtils.Core/Validators/NationalLegalCodeUtils.cs
@@ -19,13 +19,15 @@ public static class NationalLegalCodeUtils
         }
 
         nationalLegalCode = nationalLegalCode.ToEnglishNumbers();
-        nationalLegalCode = nationalLegalCode.PadLeft(11, '0');
+        const int initialZeros = 3;
         const int nationalLegalCodeLength = 11;
 
-        if (nationalLegalCode.Length != nationalLegalCodeLength)
+        if (nationalLegalCode.Length < nationalLegalCodeLength - initialZeros || nationalLegalCode.Length > nationalLegalCodeLength)
         {
             return false;
         }
+
+        nationalLegalCode = nationalLegalCode.PadLeft(11, '0');
 
         if (!nationalLegalCode.IsNumber())
         {


### PR DESCRIPTION
Padding the beginning with zero practically makes string length validation ineffective.